### PR TITLE
fix result to follow RPC specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ## Changelog:
 
+### unreleased:
+
+- fix `eth_sign` callback(error, result) now follows the RPC Result specification `Result: { id, jsonrpc, result }`
+- fix `personal_sign` callback(error, result) now follows the RPC Result specification `Result: { id, jsonrpc, result }`
+
 ### v1.1.1:
 
 - add gasPrice option to overwrite eth_gasPrice estimation

--- a/src/ethjs-custom-signer.js
+++ b/src/ethjs-custom-signer.js
@@ -132,13 +132,21 @@ SignerProvider.prototype.sendAsync = async function sendAsync(
         payload.params[0],
         payload.params[1],
       );
-      callback(null, signedData);
+      callback(null, {
+        id: payload.id,
+        jsonrpc: payload.jsonrpc,
+        result: signedData,
+      });
     } else if (payload.method === 'personal_sign') {
       const signedData = await self.options.signPersonalMessage(
         payload.params[0],
         payload.params[1],
       );
-      callback(null, signedData);
+      callback(null, {
+        id: payload.id,
+        jsonrpc: payload.jsonrpc,
+        result: signedData,
+      });
     }
     return self.provider.sendAsync(payload, callback);
   } catch (error) {


### PR DESCRIPTION
Changed `eth_sign` and `personal_sign` callback to match the JSON-RPC specification. This is a breaking change.