### PR TITLE
Concurrent tx

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 ## Changelog:
 
+### unreleased
+
+- add `getTransactionCount(address, block)` option to override `eth_getTransactionCount`. Allow custom nonce management.
+- `eth_sendTransaction` now pushes transactions into a queue and sends them sequentially.
+
 ### v1.2.0: breaking changes
 
 - overwrite `eth_gasPrice` not only for transactions
@@ -10,7 +15,7 @@
 
 ### v1.1.1:
 
-- add gasPrice option to overwrite `eth_gasPrice` estimation
+- add `gasPrice` option to override `eth_gasPrice` estimation
 
 ### v1.1.0: breaking changes
 

--- a/package.json
+++ b/package.json
@@ -10,27 +10,26 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "core-js": "3.6.1",
     "debug": "4.1.1",
-    "ethjs-provider-http": "^0.1.6",
-    "ethjs-rpc": "^0.2.0"
+    "ethjs-provider-http": "0.1.6",
+    "ethjs-rpc": "0.2.0",
+    "regenerator-runtime": "0.13.3"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-plugin-transform-runtime": "^6.23.0",
-    "babel-preset-env": "^1.6.1",
-    "eslint": "5.16.0",
-    "eslint-config-airbnb-base": "13.1.0",
-    "eslint-plugin-import": "2.17.3",
-    "prettier": "1.17.1",
-    "prettier-eslint": "^8.8.1"
+    "@babel/cli": "7.7.7",
+    "@babel/core": "7.7.7",
+    "@babel/preset-env": "7.7.7",
+    "eslint": "6.8.0",
+    "eslint-config-airbnb-base": "13.2.0",
+    "eslint-plugin-import": "2.19.1",
+    "prettier": "1.19.1",
+    "prettier-eslint": "9.0.1"
   },
   "babel": {
-    "plugins": [
-      "transform-runtime"
-    ],
     "presets": [
       [
-        "env",
+        "@babel/env",
         {
           "targets": {
             "firefox": "21"

--- a/src/ethjs-custom-signer.js
+++ b/src/ethjs-custom-signer.js
@@ -1,3 +1,5 @@
+require('core-js/stable');
+require('regenerator-runtime/runtime');
 const Debug = require('debug');
 const HTTPProvider = require('ethjs-provider-http');
 const EthRPC = require('ethjs-rpc');

--- a/src/ethjs-custom-signer.js
+++ b/src/ethjs-custom-signer.js
@@ -137,7 +137,7 @@ SignerProvider.prototype.sendAsync = async function sendAsync(
       const outputPayload = {
         id: payload.id,
         jsonrpc: payload.jsonrpc,
-        result: await self.options.getTransactionCount(payload.params),
+        result: await self.options.getTransactionCount(...payload.params),
       };
       callback(null, outputPayload);
     } else if (payload.method === 'eth_gasPrice' && self.options.gasPrice) {

--- a/src/ethjs-custom-signer.js
+++ b/src/ethjs-custom-signer.js
@@ -64,12 +64,9 @@ function SignerProvider(path, options) {
       ));
       debug('nonce', nonce);
 
-      const txToSign = Object.assign(
-        {
-          nonce,
-        },
-        payload.params[0],
-      );
+      const txToSign = Object.assign({}, payload.params[0], {
+        nonce,
+      });
       debug('txToSign', txToSign);
 
       const signedRawTx = await self.options.signTransaction(txToSign);


### PR DESCRIPTION
- added option `getTransactionCount(address, block)` to allow `eth_getTransactionCount` override
- transactions are now queued and forwarded sequentially to the http provider to respect the nonce sequence.